### PR TITLE
chore(release): bump version to v1.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 #  treecat - Interactive Directory Structure and Content Scanner
 
 [![License](https://img.shields.io/badge/License-EVL-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/Version-1.0.1-green.svg)](https://github.com/nzingx/treecat)
+[![Version](https://img.shields.io/badge/Version-1.0.2-green.svg)](https://github.com/nzingx/treecat)
 
 `treecat` is a powerful CLI tool that combines directory tree visualization with file content preview capabilities. It works in both interactive and non-interactive modes, perfect for developers who need to quickly explore project structures or document codebases.
 
@@ -84,7 +84,7 @@ treecat --issues        # View issue tracker
 Example `.treecatrc.json`:
 ```json
 {
-  "version": "1.0.1",
+  "version": "1.0.2",
   "targetDir": "./src",
   "excludeGitignore": true,
   "extensions": [".js", ".jsx"],

--- a/bin/treecat.mjs
+++ b/bin/treecat.mjs
@@ -16,7 +16,7 @@
  * Entry point for Treecat CLI.
  * Delegates execution to the main() function in lib/main.js.
  *
- * @version 1.0.1
+ * @version 1.0.2
  */
 
 import { main } from '../lib/main.js';

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -18,7 +18,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
  * Current version of the Treecat CLI.
  * @constant {string}
  */
-const VERSION = '1.0.1';
+const VERSION = '1.0.2';
 
 /**
  * Author of the Treecat CLI.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "treecat",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "View folder structure like tree and display file contents like cat — all in one CLI.",
   "keywords": [
     "cli",


### PR DESCRIPTION
## 📦 Release v1.0.2

### Summary
This PR prepares and publishes version `v1.0.2` of the project.

### Changes
- Bumped version to `v1.0.2` in:
  - `package.json`
  - `README.md`
  - `bin/treecat.mjs`
  - `lib/constants.js`
- Minor metadata updates

### Checklist
- [x] Version updated correctly
- [x] All tests passing
- [x] No breaking changes introduced
- [x] Tag `v1.0.2` created and pushed

---

> This is a minor release with no major functional changes.
